### PR TITLE
Fix checksum and clean required ffmpeg options

### DIFF
--- a/m4b-tool.rb
+++ b/m4b-tool.rb
@@ -4,11 +4,11 @@ class M4bTool < Formula
   desc "m4b-tool is a command line utility to merge, split and chapterize audiobook files such as mp3, ogg, flac, m4a or m4b"
   homepage "m4b-tool.fynder.de"
   url "https://github.com/sandreas/m4b-tool/releases/download/v.0.3.1/m4b-tool.tar.gz"
-  sha256 "91c0ed60fa240c5cd4faf642d5352b3bdde48bde6af746debff734601c47a393"
+  sha256 "e649af4bd499f50fd4aa2cb8f9f367a2feb759e748f8d7413939be06d196b731"
 
   depends_on "php"
   depends_on "mp4v2"
-  depends_on "ffmpeg" => ["with-chromaprint", "with-fdk-aac", "with-freetype", "with-libass", "with-sdl2", "with-freetype", "with-libquvi", "with-libvorbis", "with-libquvi", "with-libvpx", "with-opus", "with-x265"]
+  depends_on "ffmpeg" => ["with-chromaprint", "with-fdk-aac", "with-freetype", "with-libass"]
   depends_on "fdk-aac-encoder"
   
   def install


### PR DESCRIPTION
Fix https://github.com/sandreas/homebrew-tap/issues/1 and remove unnecessary, deprecated or turned by default ffmpeg options