### PR TITLE
Update homebrew formula for m4b-tool version 0.5.2

### DIFF
--- a/Formula/m4b-tool.rb
+++ b/Formula/m4b-tool.rb
@@ -1,11 +1,11 @@
 # brew tap sandreas/tap
 # brew install m4b-tool
 class M4bTool < Formula
-  version "0.5.0"
+  version "0.5.2"
   desc "m4b-tool is a command line utility to merge, split and chapterize audiobook files such as mp3, ogg, flac, m4a or m4b"
   homepage "https://github.com/sandreas/m4b-tool"
-  url "https://github.com/sandreas/m4b-tool/releases/download/v0.5.0/m4b-tool-0.5.0.tar.gz"
-  sha256 "341c3fcf68a9e371115ecdf10a72a563daaefa4a8b9fe9ab39e1158bc32a0514"
+  url "https://github.com/sandreas/m4b-tool/releases/download/v0.5.2/m4b-tool-0.5.2.tar.gz"
+  sha256 "569e071585edf29aa404cb6ec537bca0daaa261c3c96fe48188801d700a19fe0"
 
   depends_on "php"
   depends_on "mp4v2"


### PR DESCRIPTION
Hello @sandreas.

Thank you very much for having released version 0.5+ of this great tool. I am using it via homebrew, which is currently version 0.5.0, and noticed now that there is already version 0.5.2 here in the GitHub repository. Instead of opening an issue, I thought to just suggest the required changes here directly. But please feel free to discard and/or edit and apply the changes yourself, especially as it contains a file checksum.

By the way, I noticed an older commit for version 0.4.2 ([homebrew-tap @ 8aaeb22](https://github.com/sandreas/homebrew-tap/tree/8aaeb22eb9071f1875b7b2b8b7e161ba7535bb86)) linked in the current repository. However, _brew tap sandreas/tap_ will currently still get you version 0.5.0, so it seems to work properly.

Best regards!